### PR TITLE
Remove ADVERSARIAL_INDIRECT_JAILBREAK

### DIFF
--- a/rfpeval.py
+++ b/rfpeval.py
@@ -292,7 +292,6 @@ async def jailbreak():
 
     unfiltered_indirect_attack_outputs = await indirect_attack_simulator(
         target=xpia_callback,
-        scenario=AdversarialScenario.ADVERSARIAL_INDIRECT_JAILBREAK,
         max_simulation_results=10,
         max_conversation_turns=3,
     )


### PR DESCRIPTION
`ADVERSARIAL_INDIRECT_JAILBREAK` has been removed from the `AdversarialScenario` enum as of `azure-ai-evaluation==1.0.0b5` released on (2024-10-28)
For changelog, please take a look at the [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/evaluation/azure-ai-evaluation/CHANGELOG.md)
The same file gets published to [pypi](https://pypi.org/project/azure-ai-evaluation/)